### PR TITLE
La til valgfri batching av influxdb eventer.

### DIFF
--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/DataPointRelay.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/DataPointRelay.kt
@@ -13,7 +13,7 @@ internal interface DataPointRelay {
 
 internal object DataPointRelayFactory {
     internal fun createDataPointRelay(sensuConfig: SensuConfig): DataPointRelay {
-        return if (sensuConfig.enableEvenBatching) {
+        return if (sensuConfig.enableEventBatching) {
             BufferedDataPointRelay(sensuConfig)
         } else {
             UnbufferedDataPointRelay(sensuConfig)

--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/DataPointRelay.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/DataPointRelay.kt
@@ -1,0 +1,72 @@
+package no.nav.personbruker.dittnav.common.metrics.influx
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.influxdb.dto.Point
+import kotlin.concurrent.fixedRateTimer
+
+internal interface DataPointRelay {
+    suspend fun submitDataPoint(point: Point)
+}
+
+internal object DataPointRelayFactory {
+    internal fun createDataPointRelay(sensuConfig: SensuConfig): DataPointRelay {
+        return if (sensuConfig.enableEvenBatching) {
+            BufferedDataPointRelay(sensuConfig)
+        } else {
+            UnbufferedDataPointRelay(sensuConfig)
+        }
+    }
+}
+
+private class UnbufferedDataPointRelay(sensuConfig: SensuConfig): DataPointRelay {
+
+    private val sensuClient = SensuClient(sensuConfig.hostName, sensuConfig.hostPort)
+    private val eventsTopLevelName = sensuConfig.eventsTopLevelName
+
+    override suspend fun submitDataPoint(point: Point) {
+        sensuClient.submitEvent(SensuEvent(listOf(point), eventsTopLevelName))
+    }
+}
+
+private class BufferedDataPointRelay(sensuConfig: SensuConfig): DataPointRelay {
+
+    private val sensuClient = SensuClient(sensuConfig.hostName, sensuConfig.hostPort)
+    private val eventsTopLevelName = sensuConfig.eventsTopLevelName
+
+    private var dataPointBuffer = mutableListOf<Point>()
+    private val mutex = Mutex()
+
+    private val batchIntervalMs = 1000L / sensuConfig.eventBatchesPerSecond
+
+
+    override suspend fun submitDataPoint(point: Point) = mutex.withLock<Unit> {
+        dataPointBuffer.add(point)
+    }
+
+    init {
+        fixedRateTimer(daemon = true, initialDelay = batchIntervalMs, period = batchIntervalMs) {
+            runBlocking(Dispatchers.IO) {
+                flushDataPoints()
+            }
+        }
+    }
+
+    private suspend fun flushDataPoints() {
+
+        var currentPointBuffer: List<Point> = emptyList()
+
+        mutex.withLock {
+            if (dataPointBuffer.isNotEmpty()) {
+                currentPointBuffer = dataPointBuffer
+                dataPointBuffer = mutableListOf()
+            }
+        }
+
+        if (currentPointBuffer.isNotEmpty()) {
+            sensuClient.submitEvent(SensuEvent(currentPointBuffer, eventsTopLevelName))
+        }
+    }
+}

--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/InfluxMetricsReporter.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/InfluxMetricsReporter.kt
@@ -6,8 +6,7 @@ import java.util.concurrent.TimeUnit
 
 class InfluxMetricsReporter(sensuConfig: SensuConfig) : MetricsReporter {
 
-    private val sensuClient = SensuClient(sensuConfig.hostName, sensuConfig.hostPort)
-    private val eventsTopLevelName = sensuConfig.eventsTopLevelName
+    private val dataPointRelay = DataPointRelayFactory.createDataPointRelay(sensuConfig)
 
     override suspend fun registerDataPoint(measurement: String, fields: Map<String, Any>, tags: Map<String, String>) {
         val point = Point.measurement(measurement)
@@ -17,7 +16,7 @@ class InfluxMetricsReporter(sensuConfig: SensuConfig) : MetricsReporter {
                 .fields(fields)
                 .build()
 
-        sensuClient.submitEvent(SensuEvent(point, eventsTopLevelName))
+        dataPointRelay.submitDataPoint(point)
     }
 
     private val DEFAULT_TAGS = listOf(

--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuConfig.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuConfig.kt
@@ -9,4 +9,8 @@ data class SensuConfig (
     val namespace: String,
     val enableEvenBatching: Boolean = false,
     val eventBatchesPerSecond: Int = 3
-)
+) {
+    init {
+        require(eventBatchesPerSecond in 1..100) { "Batcher sendt per sekund må være mellom inklusive 1 og 100, men var $eventBatchesPerSecond " }
+    }
+}

--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuConfig.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuConfig.kt
@@ -6,5 +6,7 @@ data class SensuConfig (
     val eventsTopLevelName: String,
     val applicationName: String,
     val clusterName: String,
-    val namespace: String
+    val namespace: String,
+    val enableEvenBatching: Boolean = false,
+    val eventBatchesPerSecond: Int = 3
 )

--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuConfig.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuConfig.kt
@@ -7,7 +7,7 @@ data class SensuConfig (
     val applicationName: String,
     val clusterName: String,
     val namespace: String,
-    val enableEvenBatching: Boolean = false,
+    val enableEventBatching: Boolean = false,
     val eventBatchesPerSecond: Int = 3
 ) {
     init {

--- a/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuEvent.kt
+++ b/dittnav-common-metrics/src/main/kotlin/no/nav/personbruker/dittnav/common/metrics/influx/SensuEvent.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.common.metrics.influx
 import org.influxdb.dto.Point
 
 internal data class SensuEvent(
-    val dataPoint: Point,
+    val dataPoints: List<Point>,
     val name: String
 ) {
     fun toJson(): String {
@@ -13,7 +13,7 @@ internal data class SensuEvent(
                 "type": "metric",
                 "handlers": [ "events_nano" ],
                 "status": 0,
-                "output": "${dataPoint.lineProtocol()}"
+                "output": "${dataPoints.joinToString("\n") { it.lineProtocol() }}"
             }
         """.trimIndent()
     }

--- a/dittnav-common-utils/build.gradle.kts
+++ b/dittnav-common-utils/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(Kafka.Apache.clients)
     implementation(Logback.classic)
     implementation(Logstash.logbackEncoder)
+    implementation(Kotlinx.coroutines)
     testImplementation(kotlin("test-junit5"))
     testImplementation(Jjwt.api)
     testImplementation(Jjwt.impl)


### PR DESCRIPTION
La til buffering av data som sendes til influx for å forhindre unødig stor last av sensu-host ved høy trafikk.

Maks batcher sendt per sekund kan stilles fra 1 til 100, og defaulter til 3.