### PR TITLE
Legger til egen Avro-deserialiserer som returnerer null hvis den mott…

### DIFF
--- a/dittnav-common-utils/build.gradle.kts
+++ b/dittnav-common-utils/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 
 dependencies {
     api(kotlin("stdlib-jdk8"))
+    implementation(Kafka.Confluent.avroSerializer)
+    implementation(Kafka.Confluent.schemaRegistry)
     implementation(Kafka.Apache.clients)
     implementation(Logback.classic)
     implementation(Logstash.logbackEncoder)
@@ -22,6 +24,8 @@ dependencies {
 repositories {
     jcenter()
     mavenCentral()
+    maven("https://packages.confluent.io/maven")
+    maven("https://jitpack.io")
 }
 
 publishing {

--- a/dittnav-common-utils/src/main/kotlin/no/nav/personbruker/dittnav/common/util/kafka/serializer/SwallowSerializationErrorsAvroDeserializer.kt
+++ b/dittnav-common-utils/src/main/kotlin/no/nav/personbruker/dittnav/common/util/kafka/serializer/SwallowSerializationErrorsAvroDeserializer.kt
@@ -1,0 +1,34 @@
+package no.nav.personbruker.dittnav.common.util.kafka.serializer
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import org.apache.kafka.common.errors.SerializationException
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Avro deserialiserer som returnerer `null` hvis den mottar bytes som ikke kan deserialiseres til en Avro-type.
+ *
+ * Denne implementasjonen er laget for å kunne ignorere mottatte eventer som ikke lar seg deserialisere, det vil
+ * bare logges at et event ikke lot seg deserialisere og det returneres `null`. Dette gjør at appens pollere ikke
+ * stopper selv om det skulle komme et event som ikke lar seg deserialisere.
+ */
+class SwallowSerializationErrorsAvroDeserializer: KafkaAvroDeserializer {
+    constructor() : super()
+    constructor(schemaRegistryClient: SchemaRegistryClient) : super(schemaRegistryClient)
+    constructor(schemaRegistryClient: SchemaRegistryClient, pros: MutableMap<String, Any>) : super(schemaRegistryClient, pros)
+
+    private val log: Logger = LoggerFactory.getLogger(SwallowSerializationErrorsAvroDeserializer::class.java)
+
+    override fun deserialize(bytes: ByteArray): Any? {
+        var result: Any? = null
+        try {
+            result = super.deserialize(bytes)
+
+        } catch (e: SerializationException) {
+            val msg = "Eventet kunne ikke deserialiseres, og blir forkastet. Dette skjedde mest sannsynlig fordi eventet ikke var i henold til Avro-skjemaet for denne topic-en."
+            log.error(msg, e)
+        }
+        return result
+    }
+}

--- a/dittnav-common-utils/src/test/kotlin/no/nav/personbruker/dittnav/common/util/kafka/serializer/SwallowSerializationErrorsAvroDeserializerTest.kt
+++ b/dittnav-common-utils/src/test/kotlin/no/nav/personbruker/dittnav/common/util/kafka/serializer/SwallowSerializationErrorsAvroDeserializerTest.kt
@@ -1,0 +1,59 @@
+package no.nav.personbruker.dittnav.common.util.kafka.serializer
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import io.confluent.kafka.serializers.KafkaAvroSerializer
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be null`
+import org.apache.avro.Schema
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericRecordBuilder
+import org.junit.jupiter.api.Test
+
+
+class SwallowSerializationErrorsAvroDeserializerTest {
+
+    private val topic = "dummyTopic"
+    private val config = mutableMapOf<String, Any>()
+    private val schemaRegistryClient: SchemaRegistryClient
+    private val serializer: KafkaAvroSerializer
+    private val deserializer: SwallowSerializationErrorsAvroDeserializer
+
+    init {
+        config[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = "thisUrlMustBeSetAtLeastToADummyValue"
+
+        schemaRegistryClient = MockSchemaRegistryClient()
+        serializer = KafkaAvroSerializer(schemaRegistryClient, config)
+        deserializer = SwallowSerializationErrorsAvroDeserializer(schemaRegistryClient, config)
+    }
+
+    private fun createSchema(): Schema {
+        return SchemaBuilder.builder()
+                .record("record")
+                .fields()
+                .requiredBoolean("isATest")
+                .endRecord()
+    }
+
+    @Test
+    fun `should serialize valid records successfully`() {
+        val schema = createSchema()
+        val original = GenericRecordBuilder(schema)
+                .set("isATest", true)
+                .build()
+        val serialized = serializer.serialize(topic, original)
+        val deserialized  = deserializer.deserialize(topic, serialized)
+
+        deserialized `should be equal to` original
+    }
+
+    @Test
+    fun `should return null for invalid records`() {
+        val invalidSerialisedEvent = ByteArray(10)
+
+        val deserialiedRecord = deserializer.deserialize(topic, invalidSerialisedEvent)
+
+        deserialiedRecord.`should be null`()
+    }
+}


### PR DESCRIPTION
…ar noe som ikke kan deserialiseres. 

Overlater til applikasjoner som tar den i bruk å teste den. Synes det er vanskelig å teste uten å benytte en reell Avro-type, og det trenger vi vel ikke å dra inn her. 