### PR TITLE
Grenseverdien for når et token utløper settes i sekunder

### DIFF
--- a/dittnav-common-security-authenticated-user/src/main/kotlin/no/nav/personbruker/dittnav/common/security/AuthenticatedUser.kt
+++ b/dittnav-common-security-authenticated-user/src/main/kotlin/no/nav/personbruker/dittnav/common/security/AuthenticatedUser.kt
@@ -16,7 +16,7 @@ data class AuthenticatedUser (
     }
 
     override fun toString(): String {
-        return "AuthenticatedUser(ident='***', loginLevel=$loginLevel, token='***', expiryTime=$tokenExpirationTime)"
+        return "AuthenticatedUser(ident='***', loginLevel=$loginLevel, token='***', expiryTime=$tokenExpirationTime, expired=${isTokenExpired()})"
     }
 
     fun isTokenExpired(): Boolean {

--- a/dittnav-common-security-authenticated-user/src/main/kotlin/no/nav/personbruker/dittnav/common/security/AuthenticatedUser.kt
+++ b/dittnav-common-security-authenticated-user/src/main/kotlin/no/nav/personbruker/dittnav/common/security/AuthenticatedUser.kt
@@ -24,8 +24,8 @@ data class AuthenticatedUser (
         return tokenExpirationTime.isBefore(now)
     }
 
-    fun isTokenAboutToExpire(expiryThresholdInMinutes: Long): Boolean {
+    fun isTokenAboutToExpire(expiryThresholdInSeconds: Long): Boolean {
         val now = Instant.now()
-        return now.isAfter(tokenExpirationTime.minus(expiryThresholdInMinutes, ChronoUnit.MINUTES))
+        return now.isAfter(tokenExpirationTime.minus(expiryThresholdInSeconds, ChronoUnit.SECONDS))
     }
 }

--- a/dittnav-common-security-authenticated-user/src/test/kotlin/no/nav/personbruker/dittnav/common/security/AuthenticatedUserTest.kt
+++ b/dittnav-common-security-authenticated-user/src/test/kotlin/no/nav/personbruker/dittnav/common/security/AuthenticatedUserTest.kt
@@ -1,7 +1,5 @@
 package no.nav.personbruker.dittnav.common.security
 
-import io.ktor.application.*
-import io.mockk.mockk
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -52,6 +50,7 @@ internal class AuthenticatedUserTest {
         expectedExpired.isTokenExpired() `should be` true
         expectedNotExpired.isTokenExpired() `should be` false
     }
+
     @Test
     fun `Should recognize when token expiry is past a certain threshold`() {
         val moment1 = Instant.now().plus(4, ChronoUnit.MINUTES)
@@ -60,7 +59,9 @@ internal class AuthenticatedUserTest {
         val expectedExpiring = AuthenticatedUser("", 0, "", moment1)
         val expectedNotExpiring = AuthenticatedUser("", 0, "", moment2)
 
-        expectedExpiring.isTokenAboutToExpire(5) `should be` true
-        expectedNotExpiring.isTokenAboutToExpire(5) `should be` false
+        val fiveMinutesInSeconds: Long = 5 * 60
+        expectedExpiring.isTokenAboutToExpire(fiveMinutesInSeconds) `should be` true
+        expectedNotExpiring.isTokenAboutToExpire(fiveMinutesInSeconds) `should be` false
     }
+
 }


### PR DESCRIPTION
Grenseverdien for når et token utløper settes nå i sekunder, i stede for minutter.

Slik at det er mulig med mer fingranulert kontroll på når et token utløper.